### PR TITLE
fix: Improve cache-purge module detection to prevent false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to TNC Toolbox for WordPress will be documented in this file.
 
+## [2.1.1] - 2026-01-10
+
+### 🐛 Bug Fix
+- **Cache Purge Detection**: Fix false positive module detection when `ea-nginx-cache-purge` is not installed
+  - Detection now requires specific response signatures from the cache-purge module
+  - Generic NGINX 301/404/405 responses no longer trigger false detection
+- **Detection Caching**: Fix stale detection cache preventing module discovery
+  - Settings page now always performs fresh detection check
+  - No HTTP requests on regular page loads (uses cached result)
+
 ## [2.1.0] - 2026-01-08
 
 ### 🚀 Feature

--- a/tnc-toolbox/core/settings.php
+++ b/tnc-toolbox/core/settings.php
@@ -215,7 +215,7 @@ class TNC_Settings {
                                     class="regular-text" />
                             </td>
                         </tr>
-                        <?php $status = TNC_Cache_Purge::get_status(); ?>
+                        <?php $status = TNC_Cache_Purge::get_status( true ); // Force recheck on settings page ?>
                         <tr>
                             <th scope="row">
                                 <label for="tnc_selective_purge">Selective Purging?</label>

--- a/tnc-toolbox/readme.txt
+++ b/tnc-toolbox/readme.txt
@@ -1,11 +1,11 @@
 === TNC Toolbox: Web Performance ===
 Author URI: https://tnc.works
 Plugin URI: https://merlot.digital
-Donate link: 
-Contributors: 
+Donate link:
+Contributors:
 Tags: NGINX, Cache Purge, Web Performance, Automatic Purge, Freeware
 Tested up to: 6.9
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -14,11 +14,11 @@ Designed for ea-NGINX (Cache/Proxy) on cPanel+WHM. Made to help you fly online! 
 
 == Description ==
 
-TNC Toolbox aims to enhance your WordPress experience with NGINX-on-cPanel (ea-nginx). 
+TNC Toolbox aims to enhance your WordPress experience with NGINX-on-cPanel (ea-nginx).
 
 **Built for our Managed Server clients, we've open-sourced it so others can enjoy it too!**
 
-With a heavy focus on the Apache + NGINX as Reverse Caching Proxy web stack, the plugin aims to help with Website Management, Performance and Security. 
+With a heavy focus on the Apache + NGINX as Reverse Caching Proxy web stack, the plugin aims to help with Website Management, Performance and Security.
 
 > ❤️ **FOSS by [The Network Crew Pty Ltd](https://tnc.works) (TNC) for [Merlot Digital](https://merlot.digital) & the world.** ❤️
 
@@ -37,7 +37,7 @@ With a heavy focus on the Apache + NGINX as Reverse Caching Proxy web stack, the
 
 **Eager for even more capabilities?**
 
-We plan to add further features as clients & the community request it. 
+We plan to add further features as clients & the community request it.
 
 _Please let us know your ideas on [GitHub](https://github.com/The-Network-Crew/TNC-Toolbox-for-WordPress/) - we'd love to hear from you!_
 
@@ -151,6 +151,9 @@ On every website running the plugin, check that:
 _(* Change to main plugin file name may result in deactivation)_
 
 == Changelog ==
+
+= 2.1.1: Jan 10, 2026 =
+* Bug Fix: Fix false positive cache-purge module detection
 
 = 2.1.0: Jan 8, 2026 =
 * Feature: Selective Cache Purging with ea-nginx-cache-purge integration

--- a/tnc-toolbox/tnc-toolbox.php
+++ b/tnc-toolbox/tnc-toolbox.php
@@ -5,13 +5,13 @@
  * @package           TNCTOOLBOX
  * @author            The Network Crew Pty Ltd (Merlot Digital)
  * @license           gplv3
- * @version           2.1.0
+ * @version           2.1.1
  *
  * @wordpress-plugin
  * Plugin Name:       TNC Toolbox: Web Performance
  * Plugin URI:        https://merlot.digital
  * Description:       Designed for ea-NGINX (Cache/Proxy) on cPanel+WHM. Now with selective cache purging support!
- * Version:           2.1.0
+ * Version:           2.1.1
  * Author:            The Network Crew Pty Ltd (Merlot Digital)
  * Author URI:        https://tnc.works
  * Domain Path:       /locale


### PR DESCRIPTION
## Summary

v2.1.1 - Fixes false positive detection of the `ea-nginx-cache-purge` module and improves detection caching.

## Changes

### 1. False Positive Detection Fix

Previously, the plugin would incorrectly report "successful purge" even when the module was not installed.

**Problem:** When the cache-purge module is not installed, nginx may return:
- 301 redirect (to HTTPS or default host)
- 404 Not Found (generic)
- 405 Method Not Allowed

The previous code treated HTTP 404 as success ("wasn't in cache"), but this was incorrect.

**Solution - Stricter detection:**
- HTTP 200 must contain `"Successful purge"` signature in body
- HTTP 412 (Precondition Failed) is valid—only the module returns this for PURGE
- HTTP 301/404/405 now correctly return failure with actionable error message

### 2. Detection Caching Fix

Previously, if the module wasn't detected on first check, it was cached forever.

**Solution:**
- Settings page now always performs fresh detection check (`force_recheck=true`)
- No HTTP requests on regular page loads (uses cached result)
- Module discovery happens when visiting settings page

## Error Messages

| HTTP Code | Message |
|-----------|---------|
| 301/404 | "Cache purge module not detected - install ea-nginx-cache-purge" |
| 405 | "PURGE method not allowed - cache purge module not configured" |

## Testing

Verified on CloudLinux EA4 server:
- ✅ Module detected correctly (HTTP 200 + 412 responses)
- ✅ Purge operations succeed with proper signatures
- ✅ Module NOT detected when not installed (no false positives)
- ✅ Settings page always rechecks module availability
- ✅ UAPI full cache purge works when selective is disabled
- ✅ Selective purge (11 URLs) works when enabled